### PR TITLE
[fix] Make sure assets are served with a cache busting suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ docker/local/run: ## Docker: launch the previously built image, listening on por
 		${cmd}
 
 .PHONY: docker/local/shell
-docker/local/shell: docker_args ?= --rm -it
+docker/local/shell: docker_args ?= --rm -it --user app
 docker/local/shell: docker_env ?= -e SECRET_KEY=does-not-matter-here -e DATABASE_URL=sqlite:////app/shared_volume/db.sqlite3 -e ALLOWED_HOSTS=* -e SECURE_SSL_REDIRECT=
 docker/local/shell: cmd ?= bash
 docker/local/shell: user_id ?= $$(id -u)

--- a/src/project/settings/_base.py
+++ b/src/project/settings/_base.py
@@ -162,6 +162,19 @@ USE_I18N = True
 
 USE_TZ = True
 
+# File storage
+# https://docs.djangoproject.com/en/5.1/ref/settings/#storages
+STORAGES = {
+    # This is a copy of the Django default value for this setting.
+    # We'll alter it in some of our settings modules.
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/

--- a/src/project/settings/docker_build.py
+++ b/src/project/settings/docker_build.py
@@ -8,7 +8,9 @@ from ._base import *
 
 # Static assets served by Whitenoise on production
 # @link http://whitenoise.evans.io/en/stable/
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES["staticfiles"] = {
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+}
 
 LOGGING = {
     "version": 1,

--- a/src/project/settings/production.py
+++ b/src/project/settings/production.py
@@ -10,8 +10,15 @@ SESSION_COOKIE_SECURE = True
 
 # Static assets served by Whitenoise on production
 # @link http://whitenoise.evans.io/en/stable/
-MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# > The WhiteNoise middleware should be placed directly after the
+# > Django SecurityMiddleware and before all other middleware
+MIDDLEWARE.insert(
+    MIDDLEWARE.index("django.middleware.security.SecurityMiddleware") + 1,
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+)
+STORAGES["staticfiles"] = {
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+}
 
 # Logging
 LOGGING = {


### PR DESCRIPTION
THis is a regression caused by the fact that we recently upgraded Django to v5.1, with the `STATICFILES_STORAGE` setting now being removed - replaced by `STORAGES["staticfiles"]`.